### PR TITLE
Fix for APITrace mock issues.  If registered, issue a warning

### DIFF
--- a/src/main/java/org/dasein/cloud/util/APITrace.java
+++ b/src/main/java/org/dasein/cloud/util/APITrace.java
@@ -75,8 +75,11 @@ public class  APITrace {
             MBeanServer server = ManagementFactory.getPlatformMBeanServer();
             ObjectName name = new ObjectName("org.dasein:type=API");
             API api = new API();
-
-            server.registerMBean(api, name);
+            if (!server.isRegistered(name)) {
+                server.registerMBean(api, name);
+            } else {
+                logger.warn("API MBean already registered! Are you mock testing?");
+            }
         }
         catch( Throwable t ) {
             logger.error("Unable to set up API MBean: " + t.getMessage());


### PR DESCRIPTION
referencing mock testing. If unable to register throw exception(orig
behavior).
