### PR TITLE
IAM more refactoring, see description

### DIFF
--- a/src/main/java/org/dasein/cloud/identity/AbstractIdentityAndAccessSupport.java
+++ b/src/main/java/org/dasein/cloud/identity/AbstractIdentityAndAccessSupport.java
@@ -27,32 +27,28 @@ public abstract class AbstractIdentityAndAccessSupport<T extends CloudProvider> 
         throw new OperationNotSupportedException("Groups cannot be listed for user in " + getProvider().getCloudName());
     }
 
-    @Nullable
     @Override
-    public CloudPolicy getPolicy(@Nonnull String providerPolicyId) throws CloudException, InternalException {
+    public @Nullable CloudPolicy getPolicy(@Nonnull String providerPolicyId, @Nullable CloudPolicyFilterOptions options) throws CloudException, InternalException {
         throw new OperationNotSupportedException("Policies cannot be retrieved in " + getProvider().getCloudName());
     }
 
     @Override
-    public @Nonnull CloudPolicyRule[] getPolicyRules(@Nonnull String providerPolicyId) throws CloudException, InternalException {
+    public @Nonnull CloudPolicyRule[] getPolicyRules(@Nonnull String providerPolicyId, @Nullable CloudPolicyFilterOptions options) throws CloudException, InternalException {
         throw new OperationNotSupportedException("Policy rules cannot be retrieved in " + getProvider().getCloudName());
     }
 
-    @Nonnull
     @Override
-    public Iterable<CloudPolicy> listPolicies(@Nonnull CloudPolicyFilterOptions opts) throws CloudException, InternalException {
+    public @Nonnull Iterable<CloudPolicy> listPolicies(@Nonnull CloudPolicyFilterOptions opts) throws CloudException, InternalException {
         throw new OperationNotSupportedException("Policies cannot be listed in " + getProvider().getCloudName());
     }
 
-    @Nonnull
     @Override
-    public Iterable<CloudUser> listUsersInGroup(@Nonnull String inProviderGroupId) throws CloudException, InternalException {
+    public @Nonnull Iterable<CloudUser> listUsersInGroup(@Nonnull String inProviderGroupId) throws CloudException, InternalException {
         throw new OperationNotSupportedException("Users cannot be listed for group in " + getProvider().getCloudName());
     }
 
-    @Nonnull
     @Override
-    public Iterable<CloudUser> listUsersInPath(@Nullable String pathBase) throws CloudException, InternalException {
+    public @Nonnull Iterable<CloudUser> listUsersInPath(@Nullable String pathBase) throws CloudException, InternalException {
         throw new OperationNotSupportedException("Users cannot be listed in path in " + getProvider().getCloudName());
     }
 
@@ -71,9 +67,8 @@ public abstract class AbstractIdentityAndAccessSupport<T extends CloudProvider> 
         throw new OperationNotSupportedException("Access keys cannot be disabled in " + getProvider().getCloudName());
     }
 
-    @Nonnull
     @Override
-    public Iterable<AccessKey> listAccessKeys(@Nullable String providerUserId) throws CloudException, InternalException {
+    public @Nonnull Iterable<AccessKey> listAccessKeys(@Nullable String providerUserId) throws CloudException, InternalException {
         throw new OperationNotSupportedException("Access keys cannot be listed in " + getProvider().getCloudName());
     }
 
@@ -93,10 +88,10 @@ public abstract class AbstractIdentityAndAccessSupport<T extends CloudProvider> 
         throw new OperationNotSupportedException("Groups cannot be removed in " + getProvider().getCloudName());
     }
 
-    @Override
-    public void removeGroupPolicy(@Nonnull String providerGroupId, @Nonnull String providerPolicyId) throws CloudException, InternalException {
-        throw new OperationNotSupportedException("Group policies cannot be removed in " + getProvider().getCloudName());
-    }
+//    @Override
+//    public void removeGroupPolicy(@Nonnull String providerGroupId, @Nonnull String providerPolicyId) throws CloudException, InternalException {
+//        throw new OperationNotSupportedException("Group policies cannot be removed in " + getProvider().getCloudName());
+//    }
 
     @Override
     public void removeUser(@Nonnull String providerUserId) throws CloudException, InternalException {
@@ -108,27 +103,27 @@ public abstract class AbstractIdentityAndAccessSupport<T extends CloudProvider> 
         throw new OperationNotSupportedException("Users cannot be removed from groups in " + getProvider().getCloudName());
     }
 
-    @Override
-    public void removeUserPolicy(@Nonnull String providerUserId, @Nonnull String providerPolicyId) throws CloudException, InternalException {
-        throw new OperationNotSupportedException("User policies cannot be removed in " + getProvider().getCloudName());
-    }
+//    @Override
+//    public void removeUserPolicy(@Nonnull String providerUserId, @Nonnull String providerPolicyId) throws CloudException, InternalException {
+//        throw new OperationNotSupportedException("User policies cannot be removed in " + getProvider().getCloudName());
+//    }
 
     @Override
     public void modifyGroup(@Nonnull String providerGroupId, @Nullable String newGroupName, @Nullable String newPath) throws CloudException, InternalException {
         throw new OperationNotSupportedException("Groups cannot be modified in " + getProvider().getCloudName());
     }
 
-    @Nonnull
-    @Override
-    public String[] modifyGroupPolicy(@Nonnull String providerGroupId, @Nonnull String name, @Nonnull CloudPermission permission, @Nullable ServiceAction action, @Nullable String resourceId) throws CloudException, InternalException {
-        throw new OperationNotSupportedException("Groups policies cannot be modified in " + getProvider().getCloudName());
-    }
-
-    @Nonnull
-    @Override
-    public String[] modifyUserPolicy(@Nonnull String providerUserId, @Nonnull String name, @Nonnull CloudPermission permission, @Nullable ServiceAction action, @Nullable String resourceId) throws CloudException, InternalException {
-        throw new OperationNotSupportedException("User policies cannot be modified in " + getProvider().getCloudName());
-    }
+//    @Nonnull
+//    @Override
+//    public String[] modifyGroupPolicy(@Nonnull String providerGroupId, @Nonnull String name, @Nonnull CloudPermission permission, @Nullable ServiceAction action, @Nullable String resourceId) throws CloudException, InternalException {
+//        throw new OperationNotSupportedException("Groups policies cannot be modified in " + getProvider().getCloudName());
+//    }
+//
+//    @Nonnull
+//    @Override
+//    public String[] modifyUserPolicy(@Nonnull String providerUserId, @Nonnull String name, @Nonnull CloudPermission permission, @Nullable ServiceAction action, @Nullable String resourceId) throws CloudException, InternalException {
+//        throw new OperationNotSupportedException("User policies cannot be modified in " + getProvider().getCloudName());
+//    }
 
     @Override
     public void modifyUser(@Nonnull String providerUserId, @Nullable String newUserName, @Nullable String newPath) throws CloudException, InternalException {
@@ -159,7 +154,7 @@ public abstract class AbstractIdentityAndAccessSupport<T extends CloudProvider> 
     }
 
     @Override
-    public void removePolicy(@Nonnull String providerPolicyId) throws CloudException, InternalException {
+    public void removePolicy(@Nonnull String providerPolicyId, @Nullable CloudPolicyFilterOptions options) throws CloudException, InternalException {
         throw new OperationNotSupportedException("Policies cannot be removed in " + getProvider().getCloudName());
     }
 

--- a/src/main/java/org/dasein/cloud/identity/AbstractIdentityAndAccessSupport.java
+++ b/src/main/java/org/dasein/cloud/identity/AbstractIdentityAndAccessSupport.java
@@ -33,6 +33,11 @@ public abstract class AbstractIdentityAndAccessSupport<T extends CloudProvider> 
         throw new OperationNotSupportedException("Policies cannot be retrieved in " + getProvider().getCloudName());
     }
 
+    @Override
+    public @Nonnull CloudPolicyRule[] getPolicyRules(@Nonnull String providerPolicyId) throws CloudException, InternalException {
+        throw new OperationNotSupportedException("Policy rules cannot be retrieved in " + getProvider().getCloudName());
+    }
+
     @Nonnull
     @Override
     public Iterable<CloudPolicy> listPolicies(@Nonnull CloudPolicyFilterOptions opts) throws CloudException, InternalException {

--- a/src/main/java/org/dasein/cloud/identity/CloudPolicy.java
+++ b/src/main/java/org/dasein/cloud/identity/CloudPolicy.java
@@ -35,26 +35,22 @@ public class CloudPolicy {
      * @param providerPolicyId provider policy ID
      * @param name policy name
      * @param description policy description, optional
-     * @param rules policy rules used by this policy
      * @param type policy type, for {@link CloudPolicyType#INLINE_POLICY} either {@code providerUserId} or {@code providerGroupId} will be provided
      * @param providerUserId a unique user ID, for inline policies only
      * @param providerGroupId a unique group ID, for inline policies only
      * @return policy object
      */
-    static public CloudPolicy getInstance(@Nonnull String providerPolicyId, @Nonnull String name, @Nullable String description, @Nonnull CloudPolicyRule[] rules, @Nonnull CloudPolicyType type, @Nullable String providerUserId, @Nullable String providerGroupId) {
+    static public CloudPolicy getInstance(@Nonnull String providerPolicyId, @Nonnull String name, @Nullable String description, @Nonnull CloudPolicyType type, @Nullable String providerUserId, @Nullable String providerGroupId) {
         CloudPolicy policy = new CloudPolicy();
-
         policy.providerPolicyId = providerPolicyId;
         policy.name = name;
         policy.description = description;
-        policy.rules = rules;
         policy.type = type;
         policy.providerUserId = providerUserId;
         policy.providerGroupId = providerGroupId;
         return policy;
     }
 
-    private CloudPolicyRule [] rules;
     private String          name;
     private String          description;
     private String          providerPolicyId;
@@ -63,10 +59,6 @@ public class CloudPolicy {
     private CloudPolicyType type;
 
     private CloudPolicy() { }
-
-    public @Nonnull CloudPolicyRule[] getRules() {
-        return rules;
-    }
 
     public @Nonnull String getName() {
         return name;
@@ -94,6 +86,6 @@ public class CloudPolicy {
 
     @Override
     public @Nonnull String toString() {
-        return name + ":" + Arrays.toString(rules) + " [#" + providerPolicyId + "] - " + type ;
+        return name + ": [#" + providerPolicyId + "] - " + type ;
     }
 }

--- a/src/main/java/org/dasein/cloud/identity/CloudPolicyFilterOptions.java
+++ b/src/main/java/org/dasein/cloud/identity/CloudPolicyFilterOptions.java
@@ -15,8 +15,8 @@ public class CloudPolicyFilterOptions {
     /**
      * Create an instance of policy filtering options, when {@code policyTypes} includes {@link CloudPolicyType#INLINE_POLICY}
      * the {@link CloudPolicyFilterOptions#providerUserId} or {@link CloudPolicyFilterOptions#providerGroupId} are required.
-     * @param policyTypes
-     * @return
+     * @param policyTypes which policy types to include
+     * @return an instance of policy filtering options
      */
     public static CloudPolicyFilterOptions getInstance(@Nonnull CloudPolicyType ... policyTypes) {
         CloudPolicyFilterOptions opts = new CloudPolicyFilterOptions();

--- a/src/main/java/org/dasein/cloud/identity/CloudPolicyOptions.java
+++ b/src/main/java/org/dasein/cloud/identity/CloudPolicyOptions.java
@@ -14,7 +14,7 @@ public class CloudPolicyOptions {
     private String providerUserId;
     private String providerGroupId;
 
-    public static CloudPolicyOptions getInstance(@Nonnull String name, @Nonnull CloudPolicyRule[] rules) {
+    public static CloudPolicyOptions getInstance(@Nonnull String name, @Nonnull CloudPolicyRule ... rules) {
         return new CloudPolicyOptions(name, rules);
     }
 

--- a/src/main/java/org/dasein/cloud/identity/CloudPolicyRule.java
+++ b/src/main/java/org/dasein/cloud/identity/CloudPolicyRule.java
@@ -18,30 +18,30 @@ public class CloudPolicyRule {
     /**
      * Construct a new cloud policy rule instance
      * @param permission Does policy allow or deny the actions
-     * @param actions Which actions does the policy govern, all if empty
      * @param resourceId Which resource does the policy govern, any resource if {@code null}
+     * @param actions Which action does the policy govern, all if empty
      * @return new cloud policy rule instance
      */
     public static CloudPolicyRule getInstance(
             @Nonnull CloudPermission permission,
-            @Nonnull ServiceAction[] actions,
-            @Nullable String resourceId) {
-        return new CloudPolicyRule(permission, actions, false, resourceId);
+            @Nullable String resourceId,
+            @Nullable ServiceAction ... actions) {
+        return CloudPolicyRule.getInstance(permission, resourceId, false, actions);
     }
 
     /**
      * Construct a new cloud policy rule instance
      * @param permission Does policy allow or deny the actions
-     * @param actions Which actions does the policy govern, all if empty
-     * @param exceptActions Indicates if the permission will apply to all actions except the ones defined in this rule
      * @param resourceId Which resources does the policy govern, <code>null</code> for any resource
+     * @param exceptActions Indicates if the permission will apply to all actions except the ones defined in this rule
+     * @param actions Which actions does the policy govern, all if empty
      * @return new cloud policy rule instance
      */
-    public static CloudPolicyRule getInstance(@Nonnull CloudPermission permission, @Nonnull ServiceAction[] actions, boolean exceptActions, @Nullable String resourceId) {
-        return new CloudPolicyRule(permission, actions, exceptActions, resourceId);
+    public static CloudPolicyRule getInstance(@Nonnull CloudPermission permission, @Nullable String resourceId, boolean exceptActions, @Nullable ServiceAction ... actions) {
+        return new CloudPolicyRule(permission, resourceId, exceptActions, actions);
     }
 
-    private CloudPolicyRule(CloudPermission permission, ServiceAction[] actions, boolean exceptActions, String resourceId) {
+    private CloudPolicyRule(CloudPermission permission, String resourceId, boolean exceptActions, ServiceAction[] actions) {
         this.actions = actions;
         this.permission = permission;
         this.resourceId = resourceId;
@@ -69,6 +69,9 @@ public class CloudPolicyRule {
      * @return actions
      */
     public @Nonnull ServiceAction[] getActions() {
+        if( actions == null ) {
+            actions = new ServiceAction[0];
+        }
         return actions;
     }
 

--- a/src/main/java/org/dasein/cloud/identity/IdentityAndAccessCapabilities.java
+++ b/src/main/java/org/dasein/cloud/identity/IdentityAndAccessCapabilities.java
@@ -102,8 +102,8 @@ public interface IdentityAndAccessCapabilities extends Capabilities {
     /**
      * Provides the password constraints set up for the cloud account
      * @return password policy constraints
-     * @throws CloudException
-     * @throws InternalException
+     * @throws CloudException an error occurred while fetching the password constraints
+     * @throws InternalException an error occurred within Dasein Cloud implementation
      */
     @SuppressWarnings("unused")
     @Nonnull NamingConstraints getPasswordConstraints() throws CloudException, InternalException;

--- a/src/main/java/org/dasein/cloud/identity/IdentityAndAccessSupport.java
+++ b/src/main/java/org/dasein/cloud/identity/IdentityAndAccessSupport.java
@@ -262,15 +262,6 @@ public interface IdentityAndAccessSupport extends AccessControlledService {
      */
     void removeGroup(@Nonnull String providerGroupId) throws CloudException, InternalException;
 
-//    /**
-//     * Removes the specified group policy from the list of policies associated with this group
-//     * @param providerGroupId the group from which the policy is being removed
-//     * @param providerPolicyId the policy to be removed
-//     * @throws CloudException an error occurred in the cloud provider
-//     * @throws InternalException an error occurred within the Dasein Cloud implementation
-//     */
-//    void removeGroupPolicy(@Nonnull String providerGroupId, @Nonnull String providerPolicyId) throws CloudException, InternalException;
-
     /**
      * Removes the specified user from the cloud provider.
      * @param providerUserId the user to be removed
@@ -287,15 +278,6 @@ public interface IdentityAndAccessSupport extends AccessControlledService {
      * @throws InternalException an error occurred within the Dasein Cloud implementation removing the user
      */
     void removeUserFromGroup(@Nonnull String providerUserId, @Nonnull String providerGroupId) throws CloudException, InternalException;
-
-//    /**
-//     * Removes the specified user policy from the list of policies associated with this user
-//     * @param providerUserId the user from whom the policy is being removed
-//     * @param providerPolicyId the policy to be removed
-//     * @throws CloudException an error occurred in the cloud provider
-//     * @throws InternalException an error occurred within the Dasein Cloud implementation
-//     */
-//    void removeUserPolicy(@Nonnull String providerUserId, @Nonnull String providerPolicyId) throws CloudException, InternalException;
 
     /**
      * Updates the specified group with new path or name values. If <code>null</code> is specified for any value, it
@@ -394,40 +376,6 @@ public interface IdentityAndAccessSupport extends AccessControlledService {
      * @throws InternalException an error occurred  within the Dasein Cloud implementation while processing the request
      */
     void disableAccessKey(@Nonnull String sharedKeyPart, @Nullable String providerUserId) throws CloudException, InternalException;
-
-//    /**
-//     * Saves the specified permission for the specified group to the access control system of the cloud. For any
-//     * nullable parameter, <code>null</code> means that global application of the permission. For example,
-//     * a <code>null</code> action means the permission applies to all actions against that service and resource.
-//     * @param providerGroupId the group ID of the group to which this policy should apply
-//     * @param name the name of the policy
-//     * @param permission the permission being granted or denied
-//     * @param action the action against which the permission applies
-//     * @param resourceId the resource ID against which the permission applies
-//     * @return the ID or IDs of the newly created policy (can result in multiple policies)
-//     * @throws CloudException an error occurred with the cloud provider applying the permission
-//     * @throws InternalException an error occurred within Dasein Cloud processing the request
-//     */
-//
-//    @Nonnull String[] modifyGroupPolicy(@Nonnull String providerGroupId, @Nonnull String name, @Nonnull CloudPermission permission, @Nullable ServiceAction action, @Nullable String resourceId) throws CloudException, InternalException;
-
-
-//    /**
-//     * Saves the specified permission for the specified user to the access control system of the cloud. For any
-//     * nullable parameter, <code>null</code> means that global application of the permission. For example,
-//     * a <code>null</code> action means the permission applies to all actions against that service and resource.
-//     * @param providerUserId the group ID of the user to which this policy should apply
-//     * @param name the name of the policy
-//     * @param permission the permission being granted or denied
-//     * @param action the action against which the permission applies
-//     * @param resourceId the resource ID against which the permission applies
-//     * @return the ID or IDs of the newly created policy (can result in multiple policies)
-//     * @throws CloudException an error occurred with the cloud provider applying the permission
-//     * @throws InternalException an error occurred within Dasein Cloud processing the request
-//     */
-//
-//    @Nonnull String[] modifyUserPolicy(@Nonnull String providerUserId, @Nonnull String name, @Nonnull CloudPermission permission, @Nullable ServiceAction action, @Nullable String resourceId) throws CloudException, InternalException;
-
 
     /**
      * Updates the specified user with new path or user name values. If <code>null</code> is specified for any value,

--- a/src/main/java/org/dasein/cloud/identity/IdentityAndAccessSupport.java
+++ b/src/main/java/org/dasein/cloud/identity/IdentityAndAccessSupport.java
@@ -51,7 +51,7 @@ public interface IdentityAndAccessSupport extends AccessControlledService {
     ServiceAction GET_USER            = new ServiceAction("IAM:GET_USER");
     ServiceAction GET_USER_POLICY     = new ServiceAction("IAM:GET_USER_POLICY");
     ServiceAction JOIN_GROUP          = new ServiceAction("IAM:JOIN_GROUP");
-    ServiceAction LIST_ACCESS_KEY     = new ServiceAction("IAM:LIST_ACCESS_KEY");
+    ServiceAction LIST_ACCESS_KEYS    = new ServiceAction("IAM:LIST_ACCESS_KEYS");
     ServiceAction LIST_GROUP          = new ServiceAction("IAM:LIST_GROUP");
     ServiceAction LIST_USER           = new ServiceAction("IAM:LIST_USER");
     ServiceAction REMOVE_GROUP        = new ServiceAction("IAM:REMOVE_GROUP");
@@ -102,12 +102,12 @@ public interface IdentityAndAccessSupport extends AccessControlledService {
 
     /**
      * Enables the specified user to access the cloud API via their own API keys.
-     * @param providerUserId the user to grant API access to
-     * @return the access keys for the user
+     * @param providerUserId the user to grant API access to, create a root credential if {@code null}
+     * @return the access keys for the user if any, otherwise the root credentials
      * @throws CloudException an error occurred within the cloud provider enabling API access
      * @throws InternalException an error occurred within the Dasein Cloud implementation while enabling access
      */
-    @Nonnull AccessKey createAccessKey(@Nonnull String providerUserId) throws CloudException, InternalException;
+    @Nonnull AccessKey createAccessKey(@Nullable String providerUserId) throws CloudException, InternalException;
 
     /**
      * Enables console access for the specified user with the specified password.
@@ -226,7 +226,7 @@ public interface IdentityAndAccessSupport extends AccessControlledService {
     @Nonnull Iterable<CloudUser> listUsersInPath(@Nullable String pathBase) throws CloudException, InternalException;
 
     /**
-     * Removes a previously created API access key associated with a user.
+     * Removes a previously created API access key associated with a user, if any - otherwise remove root API access key
      * @param sharedKeyPart the shared part of the key to remove
      * @param providerUserId the user whose access should be removed, if any
      * @throws CloudException an error occurred in the cloud provider while removing the access key
@@ -382,7 +382,7 @@ public interface IdentityAndAccessSupport extends AccessControlledService {
     /**
      * Saves the specified permission for the specified group to the access control system of the cloud. For any
      * nullable parameter, <code>null</code> means that global application of the permission. For example,
-     * a <code>null</code> action means the prmission applies to all actions against that service and resource.
+     * a <code>null</code> action means the permission applies to all actions against that service and resource.
      * @param providerGroupId the group ID of the group to which this policy should apply
      * @param name the name of the policy                        
      * @param permission the permission being granted or denied
@@ -399,7 +399,7 @@ public interface IdentityAndAccessSupport extends AccessControlledService {
     /**
      * Saves the specified permission for the specified user to the access control system of the cloud. For any
      * nullable parameter, <code>null</code> means that global application of the permission. For example,
-     * a <code>null</code> action means the prmission applies to all actions against that service and resource.
+     * a <code>null</code> action means the permission applies to all actions against that service and resource.
      * @param providerUserId the group ID of the user to which this policy should apply
      * @param name the name of the policy                      
      * @param permission the permission being granted or denied

--- a/src/main/java/org/dasein/cloud/identity/IdentityAndAccessSupport.java
+++ b/src/main/java/org/dasein/cloud/identity/IdentityAndAccessSupport.java
@@ -148,22 +148,24 @@ public interface IdentityAndAccessSupport extends AccessControlledService {
     @Nullable CloudGroup getGroup(@Nonnull String providerGroupId) throws CloudException, InternalException;
 
     /**
-     * Provides a reference to the specified managed policy.
+     * Provides a reference to the specified managed or inline policy.
      * @param providerPolicyId the unique ID of the target policy
+     * @param options policy is assumed to be managed if {@code null}, must not be {@code null} for inline policies and should contain either a user ID or group ID which the policy is associated with.
      * @return the specified policy if it exists
      * @throws CloudException an error occurred in the cloud provider fetching the specified policy
      * @throws InternalException an error occurred in the Dasein Cloud implementation while fetching the specified policy
      */
-    @Nullable CloudPolicy getPolicy(@Nonnull String providerPolicyId) throws CloudException, InternalException;
+    @Nullable CloudPolicy getPolicy(@Nonnull String providerPolicyId, @Nullable CloudPolicyFilterOptions options) throws CloudException, InternalException;
 
     /**
-     * Provides a list of policy rules for a specific policy.
+     * Provides a list of policy rules for a specific managed or inline policy.
      * @param providerPolicyId the unique ID of the target policy
+     * @param options policy is assumed to be managed if {@code null}, must not be {@code null} for inline policies and should contain either a user ID or group ID which the policy is associated with.
      * @return the list of policy rules
      * @throws CloudException an error occurred in the cloud provider fetching the specified policy
      * @throws InternalException an error occurred in the Dasein Cloud implementation while fetching the specified policy
      */
-    @Nonnull CloudPolicyRule[] getPolicyRules(@Nonnull String providerPolicyId) throws CloudException, InternalException;
+    @Nonnull CloudPolicyRule[] getPolicyRules(@Nonnull String providerPolicyId, @Nullable CloudPolicyFilterOptions options) throws CloudException, InternalException;
 
     /**
      * Provides a reference to the specified user.
@@ -260,14 +262,14 @@ public interface IdentityAndAccessSupport extends AccessControlledService {
      */
     void removeGroup(@Nonnull String providerGroupId) throws CloudException, InternalException;
 
-    /**
-     * Removes the specified group policy from the list of policies associated with this group
-     * @param providerGroupId the group from which the policy is being removed
-     * @param providerPolicyId the policy to be removed
-     * @throws CloudException an error occurred in the cloud provider
-     * @throws InternalException an error occurred within the Dasein Cloud implementation
-     */
-    void removeGroupPolicy(@Nonnull String providerGroupId, @Nonnull String providerPolicyId) throws CloudException, InternalException;
+//    /**
+//     * Removes the specified group policy from the list of policies associated with this group
+//     * @param providerGroupId the group from which the policy is being removed
+//     * @param providerPolicyId the policy to be removed
+//     * @throws CloudException an error occurred in the cloud provider
+//     * @throws InternalException an error occurred within the Dasein Cloud implementation
+//     */
+//    void removeGroupPolicy(@Nonnull String providerGroupId, @Nonnull String providerPolicyId) throws CloudException, InternalException;
 
     /**
      * Removes the specified user from the cloud provider.
@@ -286,14 +288,14 @@ public interface IdentityAndAccessSupport extends AccessControlledService {
      */
     void removeUserFromGroup(@Nonnull String providerUserId, @Nonnull String providerGroupId) throws CloudException, InternalException;
 
-    /**
-     * Removes the specified user policy from the list of policies associated with this user
-     * @param providerUserId the user from whom the policy is being removed
-     * @param providerPolicyId the policy to be removed
-     * @throws CloudException an error occurred in the cloud provider
-     * @throws InternalException an error occurred within the Dasein Cloud implementation
-     */
-    void removeUserPolicy(@Nonnull String providerUserId, @Nonnull String providerPolicyId) throws CloudException, InternalException;
+//    /**
+//     * Removes the specified user policy from the list of policies associated with this user
+//     * @param providerUserId the user from whom the policy is being removed
+//     * @param providerPolicyId the policy to be removed
+//     * @throws CloudException an error occurred in the cloud provider
+//     * @throws InternalException an error occurred within the Dasein Cloud implementation
+//     */
+//    void removeUserPolicy(@Nonnull String providerUserId, @Nonnull String providerPolicyId) throws CloudException, InternalException;
 
     /**
      * Updates the specified group with new path or name values. If <code>null</code> is specified for any value, it
@@ -317,18 +319,23 @@ public interface IdentityAndAccessSupport extends AccessControlledService {
 
     /**
      * Modify specified policy according to the supplied options
-     * @param options description of the policy changes
+     * @param providerPolicyId target policy that is being modified
+     * @param options Description of the policy changes. User/group ID which may be passed in are used for inline policy association. For managed policy attachment use {@link #attachPolicyToUser(String, String) attachPolicyToUser} and {@link #attachPolicyToGroup(String, String) attachPolicyToGroup}.
      * @throws CloudException an error occurred with the cloud provider while modifying policy
      * @throws InternalException an error occurred within the Dasein Cloud implementation
      */
     void modifyPolicy(@Nonnull String providerPolicyId, @Nonnull CloudPolicyOptions options) throws CloudException, InternalException;
 
     /**
-     * Remove a cloud policy with the specified policy identifier
+     * Remove a cloud policy with the specified policy identifier and optionally with an options object which may
+     * be used to address a specific inline user or group policy
+     * @param providerPolicyId unique policy ID
+     * @param options policy is assumed to be managed if {@code null}, otherwise may contain a user ID or group ID for
+     *                an inline policy
      * @throws CloudException an error occurred with the cloud provider while removing policy
      * @throws InternalException an error occurred within the Dasein Cloud implementation
      */
-    void removePolicy(@Nonnull String providerPolicyId) throws CloudException, InternalException;
+    void removePolicy(@Nonnull String providerPolicyId, @Nullable CloudPolicyFilterOptions options) throws CloudException, InternalException;
 
     /**
      * Associate specified policy with the specified cloud user
@@ -388,38 +395,38 @@ public interface IdentityAndAccessSupport extends AccessControlledService {
      */
     void disableAccessKey(@Nonnull String sharedKeyPart, @Nullable String providerUserId) throws CloudException, InternalException;
 
-    /**
-     * Saves the specified permission for the specified group to the access control system of the cloud. For any
-     * nullable parameter, <code>null</code> means that global application of the permission. For example,
-     * a <code>null</code> action means the permission applies to all actions against that service and resource.
-     * @param providerGroupId the group ID of the group to which this policy should apply
-     * @param name the name of the policy                        
-     * @param permission the permission being granted or denied
-     * @param action the action against which the permission applies
-     * @param resourceId the resource ID against which the permission applies
-     * @return the ID or IDs of the newly created policy (can result in multiple policies)
-     * @throws CloudException an error occurred with the cloud provider applying the permission
-     * @throws InternalException an error occurred within Dasein Cloud processing the request
-     */
-    
-    @Nonnull String[] modifyGroupPolicy(@Nonnull String providerGroupId, @Nonnull String name, @Nonnull CloudPermission permission, @Nullable ServiceAction action, @Nullable String resourceId) throws CloudException, InternalException;
+//    /**
+//     * Saves the specified permission for the specified group to the access control system of the cloud. For any
+//     * nullable parameter, <code>null</code> means that global application of the permission. For example,
+//     * a <code>null</code> action means the permission applies to all actions against that service and resource.
+//     * @param providerGroupId the group ID of the group to which this policy should apply
+//     * @param name the name of the policy
+//     * @param permission the permission being granted or denied
+//     * @param action the action against which the permission applies
+//     * @param resourceId the resource ID against which the permission applies
+//     * @return the ID or IDs of the newly created policy (can result in multiple policies)
+//     * @throws CloudException an error occurred with the cloud provider applying the permission
+//     * @throws InternalException an error occurred within Dasein Cloud processing the request
+//     */
+//
+//    @Nonnull String[] modifyGroupPolicy(@Nonnull String providerGroupId, @Nonnull String name, @Nonnull CloudPermission permission, @Nullable ServiceAction action, @Nullable String resourceId) throws CloudException, InternalException;
 
 
-    /**
-     * Saves the specified permission for the specified user to the access control system of the cloud. For any
-     * nullable parameter, <code>null</code> means that global application of the permission. For example,
-     * a <code>null</code> action means the permission applies to all actions against that service and resource.
-     * @param providerUserId the group ID of the user to which this policy should apply
-     * @param name the name of the policy                      
-     * @param permission the permission being granted or denied
-     * @param action the action against which the permission applies
-     * @param resourceId the resource ID against which the permission applies
-     * @return the ID or IDs of the newly created policy (can result in multiple policies)
-     * @throws CloudException an error occurred with the cloud provider applying the permission
-     * @throws InternalException an error occurred within Dasein Cloud processing the request
-     */
-    
-    @Nonnull String[] modifyUserPolicy(@Nonnull String providerUserId, @Nonnull String name, @Nonnull CloudPermission permission, @Nullable ServiceAction action, @Nullable String resourceId) throws CloudException, InternalException;
+//    /**
+//     * Saves the specified permission for the specified user to the access control system of the cloud. For any
+//     * nullable parameter, <code>null</code> means that global application of the permission. For example,
+//     * a <code>null</code> action means the permission applies to all actions against that service and resource.
+//     * @param providerUserId the group ID of the user to which this policy should apply
+//     * @param name the name of the policy
+//     * @param permission the permission being granted or denied
+//     * @param action the action against which the permission applies
+//     * @param resourceId the resource ID against which the permission applies
+//     * @return the ID or IDs of the newly created policy (can result in multiple policies)
+//     * @throws CloudException an error occurred with the cloud provider applying the permission
+//     * @throws InternalException an error occurred within Dasein Cloud processing the request
+//     */
+//
+//    @Nonnull String[] modifyUserPolicy(@Nonnull String providerUserId, @Nonnull String name, @Nonnull CloudPermission permission, @Nullable ServiceAction action, @Nullable String resourceId) throws CloudException, InternalException;
 
 
     /**
@@ -437,19 +444,17 @@ public interface IdentityAndAccessSupport extends AccessControlledService {
     /**
      * List all unique ids for all services available in the cloud, as addressable by IAM policies
      * @return list of all service ids
-     * @throws CloudException
-     * @throws InternalException
+     * @throws CloudException an error occurred with the cloud provider while listing services
+     * @throws InternalException an error occurred within the Dasein Cloud implementation
      */
-    
     @Nonnull Iterable<String> listServices() throws CloudException, InternalException;
 
     /**
      * List all available actions per service, optionally selected for one individual service
      * @param forService optional service id for which to list actions
      * @return list of all available actions per given service, or if {@code forService} is {@code null} - all actions for all services
-     * @throws CloudException
-     * @throws InternalException
+     * @throws CloudException an error occurred with the cloud provider while listing service action
+     * @throws InternalException an error occurred within the Dasein Cloud implementation
      */
-    
     @Nonnull Iterable<ServiceAction> listServiceActions(@Nullable String forService) throws CloudException, InternalException;
 }

--- a/src/main/java/org/dasein/cloud/identity/IdentityAndAccessSupport.java
+++ b/src/main/java/org/dasein/cloud/identity/IdentityAndAccessSupport.java
@@ -157,6 +157,15 @@ public interface IdentityAndAccessSupport extends AccessControlledService {
     @Nullable CloudPolicy getPolicy(@Nonnull String providerPolicyId) throws CloudException, InternalException;
 
     /**
+     * Provides a list of policy rules for a specific policy.
+     * @param providerPolicyId the unique ID of the target policy
+     * @return the list of policy rules
+     * @throws CloudException an error occurred in the cloud provider fetching the specified policy
+     * @throws InternalException an error occurred in the Dasein Cloud implementation while fetching the specified policy
+     */
+    @Nonnull CloudPolicyRule[] getPolicyRules(@Nonnull String providerPolicyId) throws CloudException, InternalException;
+
+    /**
      * Provides a reference to the specified user.
      * @param providerUserId the unique ID of the target user
      * @return the specified user if it exists


### PR DESCRIPTION
In this round I went to decouple `CloudPolicyRules` from `CloudPolicy` so that the `listPolicies` call remains light and to the point: only policy id, name and description will be retrieved. The actual rules (policy documents) can be retrieved with a separate `getCloudPolicyRules()` call when the policy is being viewed or edited.

Additionally I tried to improve how we handle managed and inline policies by adding `CloudPolicyFilterOptions` parameter to relevant calls, so that a userId or a groupId could be passed: see `modifyPolicy`, `getPolicy`, `getPolicyRules`, `removePolicy`. This way we add a bit of a complexity into how these calls are prepared and made, but we also remove extra and somewhat duplicating signatures (e.g. `modifyUserPolicy`, `removeGroupPolicy` etc). 
